### PR TITLE
Require .reduce() initial value

### DIFF
--- a/base.js
+++ b/base.js
@@ -76,6 +76,8 @@ module.exports = {
 		"no-restricted-syntax": [
 			"error",
 			{
+				//Inspired by https://github.com/eslint/eslint/issues/12868#issuecomment-581515841
+				//In the future, if someone puts together an eslint rule for this, we should opt for that instead.
 				selector:
 					"CallExpression[arguments.length=1] > MemberExpression.callee > Identifier.property[name='reduce']",
 				message: "You must provide an initialValue to .reduce() to avoid catastrophic failure when the reduced array is empty.",

--- a/base.js
+++ b/base.js
@@ -73,5 +73,13 @@ module.exports = {
 		"react-hooks/rules-of-hooks": "error",
 		"react-hooks/exhaustive-deps": "warn",
 		"no-restricted-imports": ["error", { "patterns": ["lodash$"] }]
+		"no-restricted-syntax": [
+			"error",
+			{
+				selector:
+					"CallExpression[arguments.length=1] > MemberExpression.callee > Identifier.property[name='reduce']",
+				message: "You must provide an initialValue to .reduce() to avoid catastrophic failure when the reduced array is empty.",
+			},
+		],
 	}
 }

--- a/base.js
+++ b/base.js
@@ -72,7 +72,7 @@ module.exports = {
 		"react/require-render-return": "warn",
 		"react-hooks/rules-of-hooks": "error",
 		"react-hooks/exhaustive-deps": "warn",
-		"no-restricted-imports": ["error", { "patterns": ["lodash$"] }]
+		"no-restricted-imports": ["error", { "patterns": ["lodash$"] }],
 		"no-restricted-syntax": [
 			"error",
 			{


### PR DESCRIPTION
#Features
Adds an eslint rule that requires users to provide an initial value to `.reduce()` calls.

Inspired by https://github.com/eslint/eslint/issues/12868#issuecomment-581515841,