### PR TITLE
Add radix rule for parseInt

### DIFF
--- a/base.js
+++ b/base.js
@@ -23,13 +23,7 @@ module.exports = {
 				'default-case': 'off',
 				'no-dupe-class-members': 'off',
 				'no-undef': 'off',
-				'no-unused-vars': 'off',
-				"@typescript-eslint/ban-ts-comment": [1, { 
-					/** We should look into upgrading typescript-eslint.
-					 * When we do so, we should change the value here to 'allow-with-description'
-					 */
-					'ts-ignore': true
-				}]
+				'no-unused-vars': 'off'
 			}
 		}
 	],

--- a/base.js
+++ b/base.js
@@ -23,7 +23,13 @@ module.exports = {
 				'default-case': 'off',
 				'no-dupe-class-members': 'off',
 				'no-undef': 'off',
-				'no-unused-vars': 'off'
+				'no-unused-vars': 'off',
+				"@typescript-eslint/ban-ts-comment": [1, { 
+					/** We should look into upgrading typescript-eslint.
+					 * When we do so, we should change the value here to 'allow-with-description'
+					 */
+					'ts-ignore': true
+				}]
 			}
 		}
 	],

--- a/base.js
+++ b/base.js
@@ -1,87 +1,93 @@
 module.exports = {
-	"extends": ["eslint:recommended"],
-	// This is inspired by:
-	// - https://github.com/babel/babel-eslint/issues/663#issuecomment-519855344
-	// - https://github.com/facebook/create-react-app/blob/master/packages/eslint-config-react-app/index.js#L55
-	overrides: [
-		{
-			files: ["**/*.ts", "**/*.tsx"],
-			parser: "@typescript-eslint/parser",
-			parserOptions: {
-				ecmaVersion: 2018,
-				sourceType: 'module',
-				ecmaFeatures: {
-				  jsx: true,
-				},
-				// typescript-eslint specific options
-				warnOnUnsupportedTypeScriptVersion: true,
-			},
-			plugins: ["@typescript-eslint"],
-			// If adding a typescript-eslint version of an existing ESLint rule,
-			// make sure to disable the ESLint rule here.
-			rules: {
-				'default-case': 'off',
-				'no-dupe-class-members': 'off',
-				'no-undef': 'off',
-				'no-unused-vars': 'off'
-			}
-		}
-	],
-	"env": {
-		"es6": true,
-		"node": true,
-		"browser": true
-	},
-	"parserOptions": {
-		"ecmaVersion": 7,
-		"sourceType": "module",
-		"ecmaFeatures": {
-			"impliedStrict": true,
-			"jsx": true
-		}
-	},
-	"settings": {
-		"react": {
-			"pragma": "React",
-			"version": "16.0"
-		}
-	},
-	"parser": "babel-eslint",	
-	"plugins": ["react", "react-hooks"],
-	"rules": {
-		"indent": ["warn", "tab"],
-		"quotes": ["error", "single"],
-		"linebreak-style": ["error", "unix"],
-		"semi": ["error", "never"],
-		"no-unused-vars": ["warn",
-			{
-				"vars": "all",
-				"args": "none"
-			}
-		],
-		"no-console": ["error", {
-			"allow": ["warn", "error"]
-		}],
-		"react/jsx-uses-react": "error",
-		"react/jsx-uses-vars": "error",
-		"react/jsx-no-undef": "error",
-		"react/react-in-jsx-scope": "error",
-		"react/no-deprecated": "error",
-		"react/no-direct-mutation-state": "error",
-		"react/jsx-no-duplicate-props": "error",
-		"react/require-render-return": "warn",
-		"react-hooks/rules-of-hooks": "error",
-		"react-hooks/exhaustive-deps": "warn",
-		"no-restricted-imports": ["error", { "patterns": ["lodash$"] }],
-		"no-restricted-syntax": [
-			"error",
-			{
-				//Inspired by https://github.com/eslint/eslint/issues/12868#issuecomment-581515841
-				//In the future, if someone puts together an eslint rule for this, we should opt for that instead.
-				selector:
-					"CallExpression[arguments.length=1] > MemberExpression.callee > Identifier.property[name='reduce']",
-				message: "You must provide an initialValue to .reduce() to avoid catastrophic failure when the reduced array is empty.",
-			},
-		],
-	}
-}
+  extends: ["eslint:recommended"],
+  // This is inspired by:
+  // - https://github.com/babel/babel-eslint/issues/663#issuecomment-519855344
+  // - https://github.com/facebook/create-react-app/blob/master/packages/eslint-config-react-app/index.js#L55
+  overrides: [
+    {
+      files: ["**/*.ts", "**/*.tsx"],
+      parser: "@typescript-eslint/parser",
+      parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: "module",
+        ecmaFeatures: {
+          jsx: true,
+        },
+        // typescript-eslint specific options
+        warnOnUnsupportedTypeScriptVersion: true,
+      },
+      plugins: ["@typescript-eslint"],
+      // If adding a typescript-eslint version of an existing ESLint rule,
+      // make sure to disable the ESLint rule here.
+      rules: {
+        "default-case": "off",
+        "no-dupe-class-members": "off",
+        "no-undef": "off",
+        "no-unused-vars": "off",
+      },
+    },
+  ],
+  env: {
+    es6: true,
+    node: true,
+    browser: true,
+  },
+  parserOptions: {
+    ecmaVersion: 7,
+    sourceType: "module",
+    ecmaFeatures: {
+      impliedStrict: true,
+      jsx: true,
+    },
+  },
+  settings: {
+    react: {
+      pragma: "React",
+      version: "16.0",
+    },
+  },
+  parser: "babel-eslint",
+  plugins: ["react", "react-hooks"],
+  rules: {
+    radix: ["error"],
+    indent: ["warn", "tab"],
+    quotes: ["error", "single"],
+    "linebreak-style": ["error", "unix"],
+    semi: ["error", "never"],
+    "no-unused-vars": [
+      "warn",
+      {
+        vars: "all",
+        args: "none",
+      },
+    ],
+    "no-console": [
+      "error",
+      {
+        allow: ["warn", "error"],
+      },
+    ],
+    "react/jsx-uses-react": "error",
+    "react/jsx-uses-vars": "error",
+    "react/jsx-no-undef": "error",
+    "react/react-in-jsx-scope": "error",
+    "react/no-deprecated": "error",
+    "react/no-direct-mutation-state": "error",
+    "react/jsx-no-duplicate-props": "error",
+    "react/require-render-return": "warn",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
+    "no-restricted-imports": ["error", { patterns: ["lodash$"] }],
+    "no-restricted-syntax": [
+      "error",
+      {
+        //Inspired by https://github.com/eslint/eslint/issues/12868#issuecomment-581515841
+        //In the future, if someone puts together an eslint rule for this, we should opt for that instead.
+        selector:
+          "CallExpression[arguments.length=1] > MemberExpression.callee > Identifier.property[name='reduce']",
+        message:
+          "You must provide an initialValue to .reduce() to avoid catastrophic failure when the reduced array is empty.",
+      },
+    ],
+  },
+};

--- a/base.js
+++ b/base.js
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: ["eslint:recommended"],
+	"extends": ["eslint:recommended"],
 	// This is inspired by:
 	// - https://github.com/babel/babel-eslint/issues/663#issuecomment-519855344
 	// - https://github.com/facebook/create-react-app/blob/master/packages/eslint-config-react-app/index.js#L55
@@ -9,9 +9,9 @@ module.exports = {
 			parser: "@typescript-eslint/parser",
 			parserOptions: {
 				ecmaVersion: 2018,
-				sourceType: "module",
+				sourceType: 'module',
 				ecmaFeatures: {
-					jsx: true,
+				  jsx: true,
 				},
 				// typescript-eslint specific options
 				warnOnUnsupportedTypeScriptVersion: true,
@@ -20,53 +20,49 @@ module.exports = {
 			// If adding a typescript-eslint version of an existing ESLint rule,
 			// make sure to disable the ESLint rule here.
 			rules: {
-				"default-case": "off",
-				"no-dupe-class-members": "off",
-				"no-undef": "off",
-				"no-unused-vars": "off",
-			},
-		},
+				'default-case': 'off',
+				'no-dupe-class-members': 'off',
+				'no-undef': 'off',
+				'no-unused-vars': 'off'
+			}
+		}
 	],
-	env: {
-		es6: true,
-		node: true,
-		browser: true,
+	"env": {
+		"es6": true,
+		"node": true,
+		"browser": true
 	},
-	parserOptions: {
-		ecmaVersion: 7,
-		sourceType: "module",
-		ecmaFeatures: {
-			impliedStrict: true,
-			jsx: true,
-		},
+	"parserOptions": {
+		"ecmaVersion": 7,
+		"sourceType": "module",
+		"ecmaFeatures": {
+			"impliedStrict": true,
+			"jsx": true
+		}
 	},
-	settings: {
-		react: {
-			pragma: "React",
-			version: "16.0",
-		},
+	"settings": {
+		"react": {
+			"pragma": "React",
+			"version": "16.0"
+		}
 	},
-	parser: "babel-eslint",
-	plugins: ["react", "react-hooks"],
-	rules: {
-		radix: ["error"],
-		indent: ["warn", "tab"],
-		quotes: ["error", "single"],
+	"parser": "babel-eslint",	
+	"plugins": ["react", "react-hooks"],
+	"rules": {
+		"indent": ["warn", "tab"],
+		"quotes": ["error", "single"],
 		"linebreak-style": ["error", "unix"],
-		semi: ["error", "never"],
-		"no-unused-vars": [
-			"warn",
+		"semi": ["error", "never"],
+		"no-unused-vars": ["warn",
 			{
-				vars: "all",
-				args: "none",
-			},
+				"vars": "all",
+				"args": "none"
+			}
 		],
-		"no-console": [
-			"error",
-			{
-				allow: ["warn", "error"],
-			},
-		],
+		"no-console": ["error", {
+			"allow": ["warn", "error"]
+		}],
+		"radix": ["error"],
 		"react/jsx-uses-react": "error",
 		"react/jsx-uses-vars": "error",
 		"react/jsx-no-undef": "error",
@@ -77,7 +73,7 @@ module.exports = {
 		"react/require-render-return": "warn",
 		"react-hooks/rules-of-hooks": "error",
 		"react-hooks/exhaustive-deps": "warn",
-		"no-restricted-imports": ["error", { patterns: ["lodash$"] }],
+		"no-restricted-imports": ["error", { "patterns": ["lodash$"] }],
 		"no-restricted-syntax": [
 			"error",
 			{
@@ -85,9 +81,8 @@ module.exports = {
 				//In the future, if someone puts together an eslint rule for this, we should opt for that instead.
 				selector:
 					"CallExpression[arguments.length=1] > MemberExpression.callee > Identifier.property[name='reduce']",
-				message:
-					"You must provide an initialValue to .reduce() to avoid catastrophic failure when the reduced array is empty.",
+				message: "You must provide an initialValue to .reduce() to avoid catastrophic failure when the reduced array is empty.",
 			},
 		],
-	},
-};
+	}
+}

--- a/base.js
+++ b/base.js
@@ -1,93 +1,93 @@
 module.exports = {
-  extends: ["eslint:recommended"],
-  // This is inspired by:
-  // - https://github.com/babel/babel-eslint/issues/663#issuecomment-519855344
-  // - https://github.com/facebook/create-react-app/blob/master/packages/eslint-config-react-app/index.js#L55
-  overrides: [
-    {
-      files: ["**/*.ts", "**/*.tsx"],
-      parser: "@typescript-eslint/parser",
-      parserOptions: {
-        ecmaVersion: 2018,
-        sourceType: "module",
-        ecmaFeatures: {
-          jsx: true,
-        },
-        // typescript-eslint specific options
-        warnOnUnsupportedTypeScriptVersion: true,
-      },
-      plugins: ["@typescript-eslint"],
-      // If adding a typescript-eslint version of an existing ESLint rule,
-      // make sure to disable the ESLint rule here.
-      rules: {
-        "default-case": "off",
-        "no-dupe-class-members": "off",
-        "no-undef": "off",
-        "no-unused-vars": "off",
-      },
-    },
-  ],
-  env: {
-    es6: true,
-    node: true,
-    browser: true,
-  },
-  parserOptions: {
-    ecmaVersion: 7,
-    sourceType: "module",
-    ecmaFeatures: {
-      impliedStrict: true,
-      jsx: true,
-    },
-  },
-  settings: {
-    react: {
-      pragma: "React",
-      version: "16.0",
-    },
-  },
-  parser: "babel-eslint",
-  plugins: ["react", "react-hooks"],
-  rules: {
-    radix: ["error"],
-    indent: ["warn", "tab"],
-    quotes: ["error", "single"],
-    "linebreak-style": ["error", "unix"],
-    semi: ["error", "never"],
-    "no-unused-vars": [
-      "warn",
-      {
-        vars: "all",
-        args: "none",
-      },
-    ],
-    "no-console": [
-      "error",
-      {
-        allow: ["warn", "error"],
-      },
-    ],
-    "react/jsx-uses-react": "error",
-    "react/jsx-uses-vars": "error",
-    "react/jsx-no-undef": "error",
-    "react/react-in-jsx-scope": "error",
-    "react/no-deprecated": "error",
-    "react/no-direct-mutation-state": "error",
-    "react/jsx-no-duplicate-props": "error",
-    "react/require-render-return": "warn",
-    "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn",
-    "no-restricted-imports": ["error", { patterns: ["lodash$"] }],
-    "no-restricted-syntax": [
-      "error",
-      {
-        //Inspired by https://github.com/eslint/eslint/issues/12868#issuecomment-581515841
-        //In the future, if someone puts together an eslint rule for this, we should opt for that instead.
-        selector:
-          "CallExpression[arguments.length=1] > MemberExpression.callee > Identifier.property[name='reduce']",
-        message:
-          "You must provide an initialValue to .reduce() to avoid catastrophic failure when the reduced array is empty.",
-      },
-    ],
-  },
+	extends: ["eslint:recommended"],
+	// This is inspired by:
+	// - https://github.com/babel/babel-eslint/issues/663#issuecomment-519855344
+	// - https://github.com/facebook/create-react-app/blob/master/packages/eslint-config-react-app/index.js#L55
+	overrides: [
+		{
+			files: ["**/*.ts", "**/*.tsx"],
+			parser: "@typescript-eslint/parser",
+			parserOptions: {
+				ecmaVersion: 2018,
+				sourceType: "module",
+				ecmaFeatures: {
+					jsx: true,
+				},
+				// typescript-eslint specific options
+				warnOnUnsupportedTypeScriptVersion: true,
+			},
+			plugins: ["@typescript-eslint"],
+			// If adding a typescript-eslint version of an existing ESLint rule,
+			// make sure to disable the ESLint rule here.
+			rules: {
+				"default-case": "off",
+				"no-dupe-class-members": "off",
+				"no-undef": "off",
+				"no-unused-vars": "off",
+			},
+		},
+	],
+	env: {
+		es6: true,
+		node: true,
+		browser: true,
+	},
+	parserOptions: {
+		ecmaVersion: 7,
+		sourceType: "module",
+		ecmaFeatures: {
+			impliedStrict: true,
+			jsx: true,
+		},
+	},
+	settings: {
+		react: {
+			pragma: "React",
+			version: "16.0",
+		},
+	},
+	parser: "babel-eslint",
+	plugins: ["react", "react-hooks"],
+	rules: {
+		radix: ["error"],
+		indent: ["warn", "tab"],
+		quotes: ["error", "single"],
+		"linebreak-style": ["error", "unix"],
+		semi: ["error", "never"],
+		"no-unused-vars": [
+			"warn",
+			{
+				vars: "all",
+				args: "none",
+			},
+		],
+		"no-console": [
+			"error",
+			{
+				allow: ["warn", "error"],
+			},
+		],
+		"react/jsx-uses-react": "error",
+		"react/jsx-uses-vars": "error",
+		"react/jsx-no-undef": "error",
+		"react/react-in-jsx-scope": "error",
+		"react/no-deprecated": "error",
+		"react/no-direct-mutation-state": "error",
+		"react/jsx-no-duplicate-props": "error",
+		"react/require-render-return": "warn",
+		"react-hooks/rules-of-hooks": "error",
+		"react-hooks/exhaustive-deps": "warn",
+		"no-restricted-imports": ["error", { patterns: ["lodash$"] }],
+		"no-restricted-syntax": [
+			"error",
+			{
+				//Inspired by https://github.com/eslint/eslint/issues/12868#issuecomment-581515841
+				//In the future, if someone puts together an eslint rule for this, we should opt for that instead.
+				selector:
+					"CallExpression[arguments.length=1] > MemberExpression.callee > Identifier.property[name='reduce']",
+				message:
+					"You must provide an initialValue to .reduce() to avoid catastrophic failure when the reduced array is empty.",
+			},
+		],
+	},
 };


### PR DESCRIPTION
Adds an eslint rule that shows an error when calling `parseInt` without a radix paramater:

![image](https://user-images.githubusercontent.com/34781332/115313531-730b5200-a141-11eb-9375-da805bb3632a.png)

We want to only call `Number./parseFloat` if the user really wants to parse an integer that's not in Base 10.